### PR TITLE
Lifetime update and Coap initial ACK timeout update

### DIFF
--- a/samples/nrf9160/lwm2m_client/prj.conf
+++ b/samples/nrf9160/lwm2m_client/prj.conf
@@ -74,8 +74,8 @@ CONFIG_APP_LOG_LEVEL_DBG=y
 # Support HEX style PSK values (double the size + NULL char)
 CONFIG_LWM2M_SECURITY_KEY_SIZE=33
 
-# extend CoAP retry timing to 10 seconds for LTE/LTE-M
-CONFIG_COAP_INIT_ACK_TIMEOUT_MS=10000
+# extend CoAP retry timing to 4 seconds for LTE/LTE-M
+CONFIG_COAP_INIT_ACK_TIMEOUT_MS=4000
 
 # Enable CoAP extended option length
 CONFIG_COAP_EXTENDED_OPTIONS_LEN=y

--- a/samples/nrf9160/lwm2m_client/src/main.c
+++ b/samples/nrf9160/lwm2m_client/src/main.c
@@ -58,6 +58,8 @@ static struct lwm2m_ctx client = {0};
 static bool reconnect;
 static int reconnection_counter;
 static struct k_sem lwm2m_restart;
+/* Enable session lifetime check for initial boot */
+static bool update_session_lifetime = true;
 
 static void rd_client_event(struct lwm2m_ctx *client, enum lwm2m_rd_client_event client_event);
 
@@ -242,6 +244,24 @@ static void date_time_event_handler(const struct date_time_evt *evt)
 	}
 }
 
+static void rd_client_update_lifetime(int srv_obj_inst)
+{
+	char pathstr[MAX_RESOURCE_LEN];
+	uint32_t current_lifetime = 0;
+
+	uint32_t lifetime = CONFIG_LWM2M_ENGINE_DEFAULT_LIFETIME;
+
+	snprintk(pathstr, sizeof(pathstr), "1/%d/1", srv_obj_inst);
+	lwm2m_engine_get_u32(pathstr, &current_lifetime);
+
+	if (current_lifetime != lifetime) {
+		/* SET Configured value */
+		lwm2m_engine_set_u32(pathstr, lifetime);
+		LOG_DBG("Update session lifetime from %d to %d", current_lifetime, lifetime);
+	}
+	update_session_lifetime = false;
+}
+
 static void rd_client_event(struct lwm2m_ctx *client, enum lwm2m_rd_client_event client_event)
 {
 	switch (client_event) {
@@ -256,6 +276,7 @@ static void rd_client_event(struct lwm2m_ctx *client, enum lwm2m_rd_client_event
 
 	case LWM2M_RD_CLIENT_EVENT_BOOTSTRAP_REG_COMPLETE:
 		LOG_DBG("Bootstrap registration complete");
+		update_session_lifetime = true;
 		reconnection_counter = 0;
 		break;
 
@@ -271,6 +292,11 @@ static void rd_client_event(struct lwm2m_ctx *client, enum lwm2m_rd_client_event
 	case LWM2M_RD_CLIENT_EVENT_REGISTRATION_COMPLETE:
 		reconnection_counter = 0;
 		LOG_DBG("Registration complete");
+		if (update_session_lifetime) {
+			/* Read A current nserver lifetime value */
+			rd_client_update_lifetime(client->srv_obj_inst);
+		}
+
 		/* Get current time and date */
 		date_time_update_async(date_time_event_handler);
 #if defined(CONFIG_APP_GNSS)


### PR DESCRIPTION
- Change default intial coap ack timeout to 4 seconds
- Added session lifetime set after first registartion or after bootstrap